### PR TITLE
OMP from gcc makes weird decisions about the number of threads needed when using dynamic allocation

### DIFF
--- a/OpenMPProcessingDemo/OpenMPFrameworkCore/EventProcessor.cpp
+++ b/OpenMPProcessingDemo/OpenMPFrameworkCore/EventProcessor.cpp
@@ -16,6 +16,7 @@
 #include "Producer.h"
 #include "Filter.h"
 #include "WaitingTask.h"
+#include "omp.h"
 
 using namespace demo;
 
@@ -205,7 +206,7 @@ void EventProcessor::handleNextEventAsync(WaitingTaskHolder iHolder,
 
 
 
-void EventProcessor::processAll(unsigned int iNumConcurrentEvents) {
+void EventProcessor::processAll(unsigned int iNumConcurrentEvents, unsigned int auxThreads) {
   m_schedules.reserve(iNumConcurrentEvents);
 
   auto eventLoopWaitTask = std::shared_ptr<WaitingTask>(make_waiting_task([](auto) {}));
@@ -213,6 +214,7 @@ void EventProcessor::processAll(unsigned int iNumConcurrentEvents) {
   WaitingTaskHolder h( eventLoopWaitTask );
 #pragma omp parallel default(shared)
   {
+    omp_set_num_threads(auxThreads);
 #pragma omp single
     {
       for(unsigned int nEvents = 1; nEvents<iNumConcurrentEvents; ++ nEvents) {

--- a/OpenMPProcessingDemo/OpenMPFrameworkCore/EventProcessor.h
+++ b/OpenMPProcessingDemo/OpenMPFrameworkCore/EventProcessor.h
@@ -32,7 +32,7 @@ namespace demo {
     void addPath(const std::string& iName, const std::vector<std::string>& iModules);
     void addProducer(Producer* iProd);
     void addFilter(Filter* iFilter);
-    void processAll(unsigned int iNumConcurrentEvents);
+    void processAll(unsigned int iNumConcurrentEvents, unsigned int auxThreads);
     
     void finishSetup();
     

--- a/OpenMPProcessingDemo/main.cpp
+++ b/OpenMPProcessingDemo/main.cpp
@@ -114,7 +114,7 @@ int main (int argc, char * const argv[]) {
     
     //ep.processAll(2);
     unsigned int nEvents = pConfig.get<unsigned int>("process.options.nSimultaneousEvents");
-    ep.processAll(nEvents);
+    ep.processAll(nEvents, nThreads-nTopThreads+1);
     
     struct timeval tp;
     gettimeofday(&tp, 0);

--- a/OpenMPProcessingDemo/main.cpp
+++ b/OpenMPProcessingDemo/main.cpp
@@ -35,20 +35,23 @@ int main (int argc, char * const argv[]) {
 
 
   const unsigned int nThreads = pConfig.get<unsigned int>("process.options.nThreads",omp_get_max_threads());
-  setenv("OMP_THREAD_LIMIT",std::to_string(nThreads).c_str(), 0);
   assert(nThreads == omp_get_thread_limit());
 
   //if nTopThreads != nThreads then some threads are reserved for nested parallelism
   omp_set_nested(0);
   const unsigned int nTopThreads = pConfig.get<unsigned int>("process.options.nTopThreads",nThreads);
+  omp_set_num_threads(nTopThreads);
   if(nThreads != nTopThreads) {
     omp_set_max_active_levels(2);
     omp_set_nested(1);
+#ifdef __clang__
     omp_set_dynamic(1);
-  }
+#else
+    omp_set_dynamic(0);
+#endif
+   }
 
 
-  omp_set_num_threads(nTopThreads);
 
   //const size_t iterations= 3000;
   const size_t iterations = pConfig.get<size_t>("process.source.iterations");


### PR DESCRIPTION
 Also setenv seems to have no effect on OMP when called witihin the program.